### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/chrome-cordova/gcmServer/xmpp/auth.py
+++ b/chrome-cordova/gcmServer/xmpp/auth.py
@@ -137,7 +137,7 @@ class SASL(PlugIn):
         self._owner.RegisterHandler('challenge',self.SASLHandler,xmlns=NS_SASL)
         self._owner.RegisterHandler('failure',self.SASLHandler,xmlns=NS_SASL)
         self._owner.RegisterHandler('success',self.SASLHandler,xmlns=NS_SASL)
-        if "ANONYMOUS" in mecs and self.username == None:
+        if "ANONYMOUS" in mecs and self.username is None:
             node=Node('auth',attrs={'xmlns':NS_SASL,'mechanism':'ANONYMOUS'})
         elif "DIGEST-MD5" in mecs:
             node=Node('auth',attrs={'xmlns':NS_SASL,'mechanism':'DIGEST-MD5'})

--- a/chrome-cordova/gcmServer/xmpp/browser.py
+++ b/chrome-cordova/gcmServer/xmpp/browser.py
@@ -202,14 +202,14 @@ class Browser(PlugIn):
             # handler must return list: [{jid,action,node,name}]
             if type(handler)==dict: lst=handler['items']
             else: lst=handler(conn,request,'items')
-            if lst==None:
+            if lstisNone:
                 conn.send(Error(request,ERR_ITEM_NOT_FOUND))
                 raise NodeProcessed
             for item in lst: q.addChild('item',item)
         elif request.getQueryNS()==NS_DISCO_INFO:
             if type(handler)==dict: dt=handler['info']
             else: dt=handler(conn,request,'info')
-            if dt==None:
+            if dtisNone:
                 conn.send(Error(request,ERR_ITEM_NOT_FOUND))
                 raise NodeProcessed
             # handler must return dictionary:

--- a/chrome-cordova/gcmServer/xmpp/client.py
+++ b/chrome-cordova/gcmServer/xmpp/client.py
@@ -282,7 +282,7 @@ class Component(CommonClient):
             self.Namespace=auth.NS_COMPONENT_1
             self.Server=server[0]
         CommonClient.connect(self,server=server,proxy=proxy)
-        if self.connected and (self.typ=='jabberd2' or not self.typ and self.Dispatcher.Stream.features != None) and (not self.xcp):
+        if self.connected and (self.typ=='jabberd2' or not self.typ and self.Dispatcher.Stream.features is not None) and (not self.xcp):
             self.defaultNamespace=auth.NS_CLIENT
             self.Dispatcher.RegisterNamespace(self.defaultNamespace)
             self.Dispatcher.RegisterProtocol('iq',dispatcher.Iq)

--- a/chrome-cordova/gcmServer/xmpp/commands.py
+++ b/chrome-cordova/gcmServer/xmpp/commands.py
@@ -115,7 +115,7 @@ class Commands(PlugIn):
             if items != []:
                 for each in items:
                     i = self._handlers[each[0]][each[1]]['disco'](conn,request,'list')
-                    if i != None:
+                    if i is not None:
                         list.append(Node(tag='item',attrs={'jid':i[0],'node':i[1],'name':i[2]}))
                 iq = request.buildReply('result')
                 if request.getQuerynode(): iq.setQuerynode(request.getQuerynode())
@@ -227,7 +227,7 @@ class Command_Handler_Prototype(PlugIn):
             action = request.getTagAttr('command','action')
         except:
             action = None
-        if action == None: action = 'execute'
+        if action is None: action = 'execute'
         # Check session is in session list
         if self.sessions.has_key(session):
             if self.sessions[session]['jid']==request.getFrom():
@@ -243,7 +243,7 @@ class Command_Handler_Prototype(PlugIn):
                 # Jid and session don't match. Go away imposter
                 self._owner.send(Error(request,ERR_BAD_REQUEST))
                 raise NodeProcessed
-        elif session != None:
+        elif session is not None:
             # Not on this sessionid you won't.
             self._owner.send(Error(request,ERR_BAD_REQUEST))
             raise NodeProcessed
@@ -278,7 +278,7 @@ class TestCommand(Command_Handler_Prototype):
             session = request.getTagAttr('command','sessionid')
         except:
             session = None
-        if session == None:
+        if session is None:
             session = self.getSessionID()
             self.sessions[session]={'jid':request.getFrom(),'actions':{'cancel':self.cmdCancel,'next':self.cmdSecondStage,'execute':self.cmdSecondStage},'data':{'type':None}}
         # As this is the first stage we only send a form

--- a/chrome-cordova/gcmServer/xmpp/debug.py
+++ b/chrome-cordova/gcmServer/xmpp/debug.py
@@ -358,7 +358,7 @@ class Debug:
                 lst2 = self._as_one_list( l )
                 for l2 in lst2: 
                     self._append_unique_str(r, l2 )
-            elif l == None:
+            elif l is None:
                 continue
             else:
                 self._append_unique_str(r, l )

--- a/chrome-cordova/gcmServer/xmpp/dispatcher.py
+++ b/chrome-cordova/gcmServer/xmpp/dispatcher.py
@@ -238,7 +238,7 @@ class Dispatcher(PlugIn):
 
         if not direct and self._owner._route:
             if name == 'route':
-                if stanza.getAttr('error') == None:
+                if stanza.getAttr('error') is None:
                     if len(stanza.getChildren()) == 1:
                         stanza = stanza.getChildren()[0]
                         name=stanza.getName()


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:mobile-chrome-apps?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:runt18:mobile-chrome-apps?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
