### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/chrome-cordova/gcmServer/xmpp/auth.py
+++ b/chrome-cordova/gcmServer/xmpp/auth.py
@@ -142,7 +142,7 @@ class SASL(PlugIn):
         elif "DIGEST-MD5" in mecs:
             node=Node('auth',attrs={'xmlns':NS_SASL,'mechanism':'DIGEST-MD5'})
         elif "PLAIN" in mecs:
-            sasl_data='%s\x00%s\x00%s'%(self.username+'@'+self._owner.Server,self.username,self.password)
+            sasl_data='{0!s}\x00{1!s}\x00{2!s}'.format(self.username+'@'+self._owner.Server, self.username, self.password)
             node=Node('auth',attrs={'xmlns':NS_SASL,'mechanism':'PLAIN'},payload=[base64.encodestring(sasl_data).replace('\r','').replace('\n','')])
         else:
             self.startsasl='failure'
@@ -159,7 +159,7 @@ class SASL(PlugIn):
             self.startsasl='failure'
             try: reason=challenge.getChildren()[0]
             except: reason=challenge
-            self.DEBUG('Failed SASL authentification: %s'%reason,'error')
+            self.DEBUG('Failed SASL authentification: {0!s}'.format(reason),'error')
             raise NodeProcessed
         elif challenge.getName()=='success':
             self.startsasl='success'
@@ -198,8 +198,8 @@ class SASL(PlugIn):
             resp['charset']='utf-8'
             sasl_data=''
             for key in ['charset','username','realm','nonce','nc','cnonce','digest-uri','response','qop']:
-                if key in ['nc','qop','response','charset']: sasl_data+="%s=%s,"%(key,resp[key])
-                else: sasl_data+='%s="%s",'%(key,resp[key])
+                if key in ['nc','qop','response','charset']: sasl_data+="{0!s}={1!s},".format(key, resp[key])
+                else: sasl_data+='{0!s}="{1!s}",'.format(key, resp[key])
 ########################################3333
             node=Node('response',attrs={'xmlns':NS_SASL},payload=[base64.encodestring(sasl_data[:-1]).replace('\r','').replace('\n','')])
             self._owner.send(node.__str__())
@@ -245,7 +245,7 @@ class Bind(PlugIn):
         resp=self._owner.SendAndWaitForResponse(Protocol('iq',typ='set',payload=[Node('bind',attrs={'xmlns':NS_BIND},payload=resource)]))
         if isResultNode(resp):
             self.bound.append(resp.getTag('bind').getTagData('jid'))
-            self.DEBUG('Successfully bound %s.'%self.bound[-1],'ok')
+            self.DEBUG('Successfully bound {0!s}.'.format(self.bound[-1]),'ok')
             jid=JID(resp.getTag('bind').getTagData('jid'))
             self._owner.User=jid.getNode()
             self._owner.Resource=jid.getResource()
@@ -257,7 +257,7 @@ class Bind(PlugIn):
             else:
                 self.DEBUG('Session open failed.','error')
                 self.session=0
-        elif resp: self.DEBUG('Binding failed: %s.'%resp.getTag('error'),'error')
+        elif resp: self.DEBUG('Binding failed: {0!s}.'.format(resp.getTag('error')),'error')
         else:
             self.DEBUG('Binding failed: timeout expired.','error')
             return ''
@@ -313,7 +313,7 @@ class ComponentBind(PlugIn):
         self._owner.UnregisterHandler('bind',self.BindHandler,xmlns=xmlns)
         resp=self.bindresponse
         if resp and resp.getAttr('error'):
-            self.DEBUG('Binding failed: %s.'%resp.getAttr('error'),'error')
+            self.DEBUG('Binding failed: {0!s}.'.format(resp.getAttr('error')),'error')
         elif resp:
             self.DEBUG('Successfully bound.','ok')
             return 'ok'

--- a/chrome-cordova/gcmServer/xmpp/browser.py
+++ b/chrome-cordova/gcmServer/xmpp/browser.py
@@ -157,7 +157,7 @@ class Browser(PlugIn):
                 # elif TYR=='info': # returns info dictionary of the same format as shown above
                 # else: # this case is impossible for now.
         """
-        self.DEBUG('Registering handler %s for "%s" node->%s'%(handler,jid,node), 'info')
+        self.DEBUG('Registering handler {0!s} for "{1!s}" node->{2!s}'.format(handler, jid, node), 'info')
         node,key=self._traversePath(node,jid,1)
         node[key]=handler
 
@@ -191,10 +191,10 @@ class Browser(PlugIn):
             nodestr='None'
         handler=self.getDiscoHandler(node,request.getTo())
         if not handler:
-            self.DEBUG("No Handler for request with jid->%s node->%s ns->%s"%(request.getTo().__str__().encode('utf8'),nodestr.encode('utf8'),request.getQueryNS().encode('utf8')),'error')
+            self.DEBUG("No Handler for request with jid->{0!s} node->{1!s} ns->{2!s}".format(request.getTo().__str__().encode('utf8'), nodestr.encode('utf8'), request.getQueryNS().encode('utf8')),'error')
             conn.send(Error(request,ERR_ITEM_NOT_FOUND))
             raise NodeProcessed
-        self.DEBUG("Handling request with jid->%s node->%s ns->%s"%(request.getTo().__str__().encode('utf8'),nodestr.encode('utf8'),request.getQueryNS().encode('utf8')),'ok')
+        self.DEBUG("Handling request with jid->{0!s} node->{1!s} ns->{2!s}".format(request.getTo().__str__().encode('utf8'), nodestr.encode('utf8'), request.getQueryNS().encode('utf8')),'ok')
         rep=request.buildReply('result')
         if node: rep.setQuerynode(node)
         q=rep.getTag('query')

--- a/chrome-cordova/gcmServer/xmpp/client.py
+++ b/chrome-cordova/gcmServer/xmpp/client.py
@@ -61,7 +61,7 @@ class PlugIn:
         self._owner=owner
         if self.DBG_LINE not in owner.debug_flags:
             owner.debug_flags.append(self.DBG_LINE)
-        self.DEBUG('Plugging %s into %s'%(self,self._owner),'start')
+        self.DEBUG('Plugging {0!s} into {1!s}'.format(self, self._owner),'start')
         if owner.__dict__.has_key(self.__class__.__name__):
             return self.DEBUG('Plugging ignored: another instance already plugged.','error')
         self._old_owners_methods=[]
@@ -74,7 +74,7 @@ class PlugIn:
  
     def PlugOut(self):
         """ Unregister all our staff from main instance and detach from it. """
-        self.DEBUG('Plugging %s out of %s.'%(self,self._owner),'stop')
+        self.DEBUG('Plugging {0!s} out of {1!s}.'.format(self, self._owner),'stop')
         ret = None
         if self.__class__.__dict__.has_key('plugout'): ret = self.plugout()
         self._owner.debug_flags.remove(self.DBG_LINE)
@@ -328,4 +328,4 @@ class Component(CommonClient):
             else:
                 raise auth.NotAuthorized(self.SASL.startsasl)
         except:
-            self.DEBUG(self.DBG,"Failed to authenticate %s"%name,'error')
+            self.DEBUG(self.DBG,"Failed to authenticate {0!s}".format(name),'error')

--- a/chrome-cordova/gcmServer/xmpp/commands.py
+++ b/chrome-cordova/gcmServer/xmpp/commands.py
@@ -214,7 +214,7 @@ class Command_Handler_Prototype(PlugIn):
     def getSessionID(self):
         """Returns an id for the command session"""
         self.count = self.count+1
-        return 'cmd-%s-%d'%(self.name,self.count)
+        return 'cmd-{0!s}-{1:d}'.format(self.name, self.count)
 
     def Execute(self,conn,request):
         """The method that handles all the commands, and routes them to the correct method for that stage."""

--- a/chrome-cordova/gcmServer/xmpp/debug.py
+++ b/chrome-cordova/gcmServer/xmpp/debug.py
@@ -185,7 +185,7 @@ class Debug:
             self._fh = sys.stdout
          
         if time_stamp not in (0,1,2):
-            msg2 = '%s' % time_stamp
+            msg2 = '{0!s}'.format(time_stamp)
             raise 'Invalid time_stamp param', msg2
         self.prefix = prefix
         self.sufix = sufix
@@ -198,17 +198,17 @@ class Debug:
             self.show('')
             caller = sys._getframe(1) # used to get name of caller
             try:
-                mod_name= ":%s" % caller.f_locals['__name__']
+                mod_name= ":{0!s}".format(caller.f_locals['__name__'])
             except:
                 mod_name = ""
-            self.show('Debug created for %s%s' % (caller.f_code.co_filename,
+            self.show('Debug created for {0!s}{1!s}'.format(caller.f_code.co_filename,
                                                    mod_name ))
-            self.show(' flags defined: %s' % ','.join( self.active ))
+            self.show(' flags defined: {0!s}'.format(','.join( self.active )))
             
         if type(flag_show) in (type(''), type(None)):
             self.flag_show = flag_show
         else:
-            msg2 = '%s' % type(flag_show )
+            msg2 = '{0!s}'.format(type(flag_show ))
             raise 'Invalid type for flag_show!', msg2
 
 
@@ -245,27 +245,27 @@ class Debug:
             suf = self.sufix
 
         if self.time_stamp == 2:
-            output = '%s%s ' % ( pre,
+            output = '{0!s}{1!s} '.format(pre,
                                  time.strftime('%b %d %H:%M:%S',
-                                 time.localtime(time.time() )),
+                                 time.localtime(time.time() ))
                                  )
         elif self.time_stamp == 1:
-            output = '%s %s' % ( time.strftime('%b %d %H:%M:%S',
+            output = '{0!s} {1!s}'.format(time.strftime('%b %d %H:%M:%S',
                                  time.localtime(time.time() )),
-                                 pre,
+                                 pre
                                  )
         else:
             output = pre
             
         if self.flag_show:
             if flag:
-                output = '%s%s%s' % ( output, flag, self.flag_show )
+                output = '{0!s}{1!s}{2!s}'.format(output, flag, self.flag_show )
             else:
                 # this call uses the global default,
                 # dont print "None", just show the separator
-                output = '%s %s' % ( output, self.flag_show )
+                output = '{0!s} {1!s}'.format(output, self.flag_show )
 
-        output = '%s%s%s' % ( output, msg, suf )
+        output = '{0!s}{1!s}{2!s}'.format(output, msg, suf )
         if lf:
             # strip/add lf if needed
             last_char = output[-1]
@@ -284,7 +284,7 @@ class Debug:
                 else:
                     c = '?'
                 s=s+c
-            self._fh.write( '%s%s%s' % ( pre, s, suf ))
+            self._fh.write( '{0!s}{1!s}{2!s}'.format(pre, s, suf ))
         self._fh.flush()
             
                 
@@ -316,7 +316,7 @@ class Debug:
             flags = self._as_one_list( active_flags )
             for t in flags:
                 if t not in self.debug_flags:
-                    sys.stderr.write('Invalid debugflag given: %s\n' % t )
+                    sys.stderr.write('Invalid debugflag given: {0!s}\n'.format(t) )
                 ok_flags.append( t )
                 
             self.active = ok_flags
@@ -327,7 +327,7 @@ class Debug:
                 flags = active_flags.split(',')
             except:
                 self.show( '***' )
-                self.show( '*** Invalid debug param given: %s' % active_flags )
+                self.show( '*** Invalid debug param given: {0!s}'.format(active_flags) )
                 self.show( '*** please correct your param!' )
                 self.show( '*** due to this, full debuging is enabled' )
                 self.active = self.debug_flags
@@ -368,7 +368,7 @@ class Debug:
     def _append_unique_str( self, lst, item ):
         """filter out any dupes."""
         if type(item) <> type(''):
-            msg2 = '%s' % item
+            msg2 = '{0!s}'.format(item)
             raise 'Invalid item type (should be string)',msg2
         if item not in lst:
             lst.append( item )
@@ -380,7 +380,7 @@ class Debug:
         if flags:
             for f in self._as_one_list( flags ):
                 if not f in self.debug_flags:
-                    msg2 = '%s' % f
+                    msg2 = '{0!s}'.format(f)
                     raise 'Invalid debugflag given', msg2
 
     def _remove_dupe_flags( self ):

--- a/chrome-cordova/gcmServer/xmpp/dispatcher.py
+++ b/chrome-cordova/gcmServer/xmpp/dispatcher.py
@@ -97,11 +97,11 @@ class Dispatcher(PlugIn):
         self._metastream.setAttr('version','1.0')
         self._metastream.setAttr('xmlns:stream',NS_STREAMS)
         self._metastream.setAttr('to',self._owner.Server)
-        self._owner.send("<?xml version='1.0'?>%s>"%str(self._metastream)[:-2])
+        self._owner.send("<?xml version='1.0'?>{0!s}>".format(str(self._metastream)[:-2]))
 
     def _check_stream_start(self,ns,tag,attrs):
         if ns<>NS_STREAMS or tag<>'stream':
-            raise ValueError('Incorrect stream start: (%s,%s). Terminating.'%(tag,ns))
+            raise ValueError('Incorrect stream start: ({0!s},{1!s}). Terminating.'.format(tag, ns))
 
     def Process(self, timeout=0):
         """ Check incoming stream for data waiting. If "timeout" is positive - block for as max. this time.
@@ -130,7 +130,7 @@ class Dispatcher(PlugIn):
         """ Creates internal structures for newly registered namespace.
             You can register handlers for this namespace afterwards. By default one namespace
             already registered (jabber:client or jabber:component:accept depending on context. """
-        self.DEBUG('Registering namespace "%s"'%xmlns,order)
+        self.DEBUG('Registering namespace "{0!s}"'.format(xmlns),order)
         self.handlers[xmlns]={}
         self.RegisterProtocol('unknown',Protocol,xmlns=xmlns)
         self.RegisterProtocol('default',Protocol,xmlns=xmlns)
@@ -140,7 +140,7 @@ class Dispatcher(PlugIn):
            Needed to start registering handlers for such stanzas.
            Iq, message and presence protocols are registered by default. """
         if not xmlns: xmlns=self._owner.defaultNamespace
-        self.DEBUG('Registering protocol "%s" as %s(%s)'%(tag_name,Proto,xmlns), order)
+        self.DEBUG('Registering protocol "{0!s}" as {1!s}({2!s})'.format(tag_name, Proto, xmlns), order)
         self.handlers[xmlns][tag_name]={type:Proto, 'default':[]}
 
     def RegisterNamespaceHandler(self,xmlns,handler,typ='',ns='', makefirst=0, system=0):
@@ -166,7 +166,7 @@ class Dispatcher(PlugIn):
               "system" - call handler even if NodeProcessed Exception were raised already.
             """
         if not xmlns: xmlns=self._owner.defaultNamespace
-        self.DEBUG('Registering handler %s for "%s" type->%s ns->%s(%s)'%(handler,name,typ,ns,xmlns), 'info')
+        self.DEBUG('Registering handler {0!s} for "{1!s}" type->{2!s} ns->{3!s}({4!s})'.format(handler, name, typ, ns, xmlns), 'info')
         if not typ and not ns: typ='default'
         if not self.handlers.has_key(xmlns): self.RegisterNamespace(xmlns,'warn')
         if not self.handlers[xmlns].has_key(name): self.RegisterProtocol(name,Protocol,xmlns,'warn')
@@ -263,7 +263,7 @@ class Dispatcher(PlugIn):
             self.DEBUG("Unknown stanza: " + name,'warn')
             name='unknown'
         else:
-            self.DEBUG("Got %s/%s stanza"%(xmlns,name), 'ok')
+            self.DEBUG("Got {0!s}/{1!s} stanza".format(xmlns, name), 'ok')
 
         if stanza.__class__.__name__=='Node': stanza=self.handlers[xmlns][name][type](node=stanza)
 
@@ -272,7 +272,7 @@ class Dispatcher(PlugIn):
         stanza.props=stanza.getProperties()
         ID=stanza.getID()
 
-        session.DEBUG("Dispatching %s stanza with type->%s props->%s id->%s"%(name,typ,stanza.props,ID),'ok')
+        session.DEBUG("Dispatching {0!s} stanza with type->{1!s} props->{2!s} id->{3!s}".format(name, typ, stanza.props, ID),'ok')
 
         list=['default']                                                     # we will use all handlers:
         if self.handlers[xmlns][name].has_key(typ): list.append(typ)                # from very common...
@@ -289,7 +289,7 @@ class Dispatcher(PlugIn):
             user=0
             if type(session._expected[ID])==type(()):
                 cb,args=session._expected[ID]
-                session.DEBUG("Expected stanza arrived. Callback %s(%s) found!"%(cb,args),'ok')
+                session.DEBUG("Expected stanza arrived. Callback {0!s}({1!s}) found!".format(cb, args),'ok')
                 try: cb(session,stanza,**args)
                 except Exception, typ:
                     if typ.__class__.__name__<>'NodeProcessed': raise
@@ -316,7 +316,7 @@ class Dispatcher(PlugIn):
         self._expected[ID]=None
         has_timed_out=0
         abort_time=time.time() + timeout
-        self.DEBUG("Waiting for ID:%s with timeout %s..." % (ID,timeout),'wait')
+        self.DEBUG("Waiting for ID:{0!s} with timeout {1!s}...".format(ID, timeout),'wait')
         while not self._expected[ID]:
             if not self.Process(0.04):
                 self._owner.lastErr="Disconnect"

--- a/chrome-cordova/gcmServer/xmpp/filetransfer.py
+++ b/chrome-cordova/gcmServer/xmpp/filetransfer.py
@@ -48,7 +48,7 @@ class IBB(PlugIn):
     def IqHandler(self,conn,stanza):
         """ Handles streams state change. Used internally. """
         typ=stanza.getType()
-        self.DEBUG('IqHandler called typ->%s'%typ,'info')
+        self.DEBUG('IqHandler called typ->{0!s}'.format(typ),'info')
         if typ=='set' and stanza.getTag('open',namespace=NS_IBB): self.StreamOpenHandler(conn,stanza)
         elif typ=='set' and stanza.getTag('close',namespace=NS_IBB): self.StreamCloseHandler(conn,stanza)
         elif typ=='result': self.StreamCommitHandler(conn,stanza)
@@ -70,14 +70,14 @@ class IBB(PlugIn):
 """
         err=None
         sid,blocksize=stanza.getTagAttr('open','sid'),stanza.getTagAttr('open','block-size')
-        self.DEBUG('StreamOpenHandler called sid->%s blocksize->%s'%(sid,blocksize),'info')
+        self.DEBUG('StreamOpenHandler called sid->{0!s} blocksize->{1!s}'.format(sid, blocksize),'info')
         try: blocksize=int(blocksize)
         except: err=ERR_BAD_REQUEST
         if not sid or not blocksize: err=ERR_BAD_REQUEST
         elif sid in self._streams.keys(): err=ERR_UNEXPECTED_REQUEST
         if err: rep=Error(stanza,err)
         else:
-            self.DEBUG("Opening stream: id %s, block-size %s"%(sid,blocksize),'info')
+            self.DEBUG("Opening stream: id {0!s}, block-size {1!s}".format(sid, blocksize),'info')
             rep=Protocol('iq',stanza.getFrom(),'result',stanza.getTo(),{'id':stanza.getID()})
             self._streams[sid]={'direction':'<'+str(stanza.getFrom()),'block-size':blocksize,'fp':open('/tmp/xmpp_file_'+sid,'w'),'seq':0,'syn_id':stanza.getID()}
         conn.send(rep)
@@ -139,7 +139,7 @@ class IBB(PlugIn):
             it to temporary file. Used internally.
         """
         sid,seq,data=stanza.getTagAttr('data','sid'),stanza.getTagAttr('data','seq'),stanza.getTagData('data')
-        self.DEBUG('ReceiveHandler called sid->%s seq->%s'%(sid,seq),'info')
+        self.DEBUG('ReceiveHandler called sid->{0!s} seq->{1!s}'.format(sid, seq),'info')
         try: seq=int(seq); data=base64.decodestring(data)
         except: seq=''; data=''
         err=None
@@ -149,18 +149,18 @@ class IBB(PlugIn):
             if not data: err=ERR_BAD_REQUEST
             elif seq<>stream['seq']: err=ERR_UNEXPECTED_REQUEST
             else:
-                self.DEBUG('Successfull receive sid->%s %s+%s bytes'%(sid,stream['fp'].tell(),len(data)),'ok')
+                self.DEBUG('Successfull receive sid->{0!s} {1!s}+{2!s} bytes'.format(sid, stream['fp'].tell(), len(data)),'ok')
                 stream['seq']+=1
                 stream['fp'].write(data)
         if err:
-            self.DEBUG('Error on receive: %s'%err,'error')
+            self.DEBUG('Error on receive: {0!s}'.format(err),'error')
             conn.send(Error(Iq(to=stanza.getFrom(),frm=stanza.getTo(),payload=[Node(NS_IBB+' close')]),err,reply=0))
 
     def StreamCloseHandler(self,conn,stanza):
         """ Handle stream closure due to all data transmitted.
             Raise xmpppy event specifying successfull data receive. """
         sid=stanza.getTagAttr('close','sid')
-        self.DEBUG('StreamCloseHandler called sid->%s'%sid,'info')
+        self.DEBUG('StreamCloseHandler called sid->{0!s}'.format(sid),'info')
         if sid in self._streams.keys():
             conn.send(stanza.buildReply('result'))
             conn.Event(self.DBG_LINE,'SUCCESSFULL RECEIVE',self._streams[sid])
@@ -171,7 +171,7 @@ class IBB(PlugIn):
         """ Handle stream closure due to all some error while receiving data.
             Raise xmpppy event specifying unsuccessfull data receive. """
         syn_id=stanza.getID()
-        self.DEBUG('StreamBrokenHandler called syn_id->%s'%syn_id,'info')
+        self.DEBUG('StreamBrokenHandler called syn_id->{0!s}'.format(syn_id),'info')
         for sid in self._streams.keys():
             stream=self._streams[sid]
             if stream['syn_id']==syn_id:
@@ -184,7 +184,7 @@ class IBB(PlugIn):
             Used internally. Raises xmpppy event specfiying if the data transfer
             is agreed upon."""
         syn_id=stanza.getID()
-        self.DEBUG('StreamOpenReplyHandler called syn_id->%s'%syn_id,'info')
+        self.DEBUG('StreamOpenReplyHandler called syn_id->{0!s}'.format(syn_id),'info')
         for sid in self._streams.keys():
             stream=self._streams[sid]
             if stream['syn_id']==syn_id:

--- a/chrome-cordova/gcmServer/xmpp/roster.py
+++ b/chrome-cordova/gcmServer/xmpp/roster.py
@@ -69,7 +69,7 @@ class Roster(PlugIn):
             if item.getAttr('subscription')=='remove':
                 if self._data.has_key(jid): del self._data[jid]
                 raise NodeProcessed             # a MUST
-            self.DEBUG('Setting roster item %s...'%jid,'ok')
+            self.DEBUG('Setting roster item {0!s}...'.format(jid),'ok')
             if not self._data.has_key(jid): self._data[jid]={}
             self._data[jid]['name']=item.getAttr('name')
             self._data[jid]['ask']=item.getAttr('ask')
@@ -91,7 +91,7 @@ class Roster(PlugIn):
         typ=pres.getType()
 
         if not typ:
-            self.DEBUG('Setting roster item %s for resource %s...'%(jid.getStripped(),jid.getResource()),'ok')
+            self.DEBUG('Setting roster item {0!s} for resource {1!s}...'.format(jid.getStripped(), jid.getResource()),'ok')
             item['resources'][jid.getResource()]=res={'show':None,'status':None,'priority':'0','timestamp':None}
             if pres.getTag('show'): res['show']=pres.getShow()
             if pres.getTag('status'): res['status']=pres.getStatus()

--- a/chrome-cordova/gcmServer/xmpp/simplexml.py
+++ b/chrome-cordova/gcmServer/xmpp/simplexml.py
@@ -118,10 +118,10 @@ class Node(object):
         if self.namespace:
             if not self.parent or self.parent.namespace!=self.namespace:
                 if 'xmlns' not in self.attrs:
-                    s = s + ' xmlns="%s"'%self.namespace
+                    s = s + ' xmlns="{0!s}"'.format(self.namespace)
         for key in self.attrs.keys():
             val = ustr(self.attrs[key])
-            s = s + ' %s="%s"' % ( key, XMLescape(val) )
+            s = s + ' {0!s}="{1!s}"'.format(key, XMLescape(val) )
         s = s + ">"
         cnt = 0
         if self.kids:
@@ -403,7 +403,7 @@ class NodeBuilder:
         """XML Parser callback. Used internally"""
         self.check_data_buffer()
         self._inc_depth()
-        self.DEBUG(DBG_NODEBUILDER, "DEPTH -> %i , tag -> %s, attrs -> %s" % (self.__depth, tag, `attrs`), 'down')
+        self.DEBUG(DBG_NODEBUILDER, "DEPTH -> {0:d} , tag -> {1!s}, attrs -> {2!s}".format(self.__depth, tag, `attrs`), 'down')
         if self.__depth == self._dispatch_depth:
             if not self._mini_dom :
                 self._mini_dom = Node(tag=tag, attrs=attrs, nsp = self._document_nsp, node_built=True)
@@ -436,7 +436,7 @@ class NodeBuilder:
 
     def endtag(self, tag ):
         """XML Parser callback. Used internally"""
-        self.DEBUG(DBG_NODEBUILDER, "DEPTH -> %i , tag -> %s" % (self.__depth, tag), 'up')
+        self.DEBUG(DBG_NODEBUILDER, "DEPTH -> {0:d} , tag -> {1!s}".format(self.__depth, tag), 'up')
         self.check_data_buffer()
         if self.__depth == self._dispatch_depth:
             if self._mini_dom.getName() == 'error':

--- a/chrome-cordova/gcmServer/xmpp/transports.py
+++ b/chrome-cordova/gcmServer/xmpp/transports.py
@@ -98,7 +98,7 @@ class TCPsocket(PlugIn):
                             port = int(port)
                             break
                 except:
-                    self.DEBUG('An error occurred while looking up %s' % query, 'warn')
+                    self.DEBUG('An error occurred while looking up {0!s}'.format(query), 'warn')
             server = (host, port)
         else:
             self.DEBUG("Could not load one of the supported DNS libraries (dnspython or pydns). SRV records will not be queried and you may need to set custom hostname/port for some servers to be accessible.\n",'warn')
@@ -133,10 +133,10 @@ class TCPsocket(PlugIn):
             self._sock.connect((server[0], int(server[1])))
             self._send=self._sock.sendall
             self._recv=self._sock.recv
-            self.DEBUG("Successfully connected to remote host %s"%`server`,'start')
+            self.DEBUG("Successfully connected to remote host {0!s}".format(`server`),'start')
             return 'ok'
         except socket.error, (errno, strerror): 
-            self.DEBUG("Failed to connect to remote host %s: %s (%s)"%(`server`, strerror, errno),'error')
+            self.DEBUG("Failed to connect to remote host {0!s}: {1!s} ({2!s})".format(`server`, strerror, errno),'error')
         except: pass
 
     def plugout(self):
@@ -233,13 +233,13 @@ class HTTPPROXYsocket(TCPsocket):
             connection to the target server. Returns non-empty sting on success. """
         if not TCPsocket.connect(self,(self._proxy['host'],self._proxy['port'])): return
         self.DEBUG("Proxy server contacted, performing authentification",'start')
-        connector = ['CONNECT %s:%s HTTP/1.0'%self._server,
+        connector = ['CONNECT {0!s}:{1!s} HTTP/1.0'.format(*self._server),
             'Proxy-Connection: Keep-Alive',
             'Pragma: no-cache',
-            'Host: %s:%s'%self._server,
+            'Host: {0!s}:{1!s}'.format(*self._server),
             'User-Agent: HTTPPROXYsocket/v0.1']
         if self._proxy.has_key('user') and self._proxy.has_key('password'):
-            credentials = '%s:%s'%(self._proxy['user'],self._proxy['password'])
+            credentials = '{0!s}:{1!s}'.format(self._proxy['user'], self._proxy['password'])
             credentials = base64.encodestring(credentials).strip()
             connector.append('Proxy-Authorization: Basic '+credentials)
         connector.append('\r\n')
@@ -252,7 +252,7 @@ class HTTPPROXYsocket(TCPsocket):
         try: proto,code,desc=reply.split('\n')[0].split(' ',2)
         except: raise error('Invalid proxy reply')
         if code<>'200':
-            self.DEBUG('Invalid proxy reply: %s %s %s'%(proto,code,desc),'error')
+            self.DEBUG('Invalid proxy reply: {0!s} {1!s} {2!s}'.format(proto, code, desc),'error')
             self._owner.disconnected()
             return
         while reply.find('\n\n') == -1:
@@ -301,7 +301,7 @@ class TLS(PlugIn):
         self.DEBUG("TLS supported by remote server. Requesting TLS start.",'ok')
         self._owner.RegisterHandlerOnce('proceed',self.StartTLSHandler,xmlns=NS_TLS)
         self._owner.RegisterHandlerOnce('failure',self.StartTLSHandler,xmlns=NS_TLS)
-        self._owner.Connection.send('<starttls xmlns="%s"/>'%NS_TLS)
+        self._owner.Connection.send('<starttls xmlns="{0!s}"/>'.format(NS_TLS))
         raise NodeProcessed
 
     def pending_data(self,timeout=0):


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:mobile-chrome-apps?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:mobile-chrome-apps?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
